### PR TITLE
[20129] Complete test cases

### DIFF
--- a/IDL/annotations.idl
+++ b/IDL/annotations.idl
@@ -25,7 +25,7 @@
     InnerEnumHelper enum_value;
     InnerEnumHelper enum_default_value default TWO;
     const short inner_const_helper = 10;
-    typedef string<10> Inner_alias_bounded_string_helper;
+    typedef string<inner_const_helper> Inner_alias_bounded_string_helper;
     Inner_alias_bounded_string_helper var_string_10;
     Inner_alias_bounded_string_helper var_default_string_10 default "Hello";
     Inner_alias_bounded_wstring_helper var_wstring_alias;

--- a/IDL/annotations.idl
+++ b/IDL/annotations.idl
@@ -1,5 +1,3 @@
-#include "helpers/basic_inner_types.idl"
-
 @annotation AnnotationTest
 {
     short var_short;

--- a/IDL/annotations.idl
+++ b/IDL/annotations.idl
@@ -1,3 +1,5 @@
+#include "helpers/basic_inner_types.idl"
+
 @annotation AnnotationTest
 {
     short var_short;
@@ -22,6 +24,11 @@
     };
     InnerEnumHelper enum_value;
     InnerEnumHelper enum_default_value default TWO;
+    const short inner_const_helper = 10;
+    typedef string<10> Inner_alias_bounded_string_helper;
+    Inner_alias_bounded_string_helper var_string_10;
+    Inner_alias_bounded_string_helper var_default_string_10 default "Hello";
+    Inner_alias_bounded_wstring_helper var_wstring_alias;
 };
 
 @annotation EmptyAnnotationTest

--- a/IDL/constants.idl
+++ b/IDL/constants.idl
@@ -21,8 +21,6 @@ const int32 const_int32 = 74;
 const uint32 const_uint32 = 64;
 const int64 const_int64 = 17;
 const uint64 const_uint64 = 19;
-const string const_string = "AAA";
-const wstring const_wstring = L"BBB";
 
 typedef short alias_short;
 const alias_short alias_const = 55;
@@ -38,6 +36,8 @@ module const_module1
     {
         short module1_array_literal_const_moduled[const_moduled];
         short module1_array_literal_const_alias_const_moduled[alias_const_moduled];
+        alias_short var1;
+        alias_short_moduled var2;
     };
 };
 

--- a/IDL/constants.idl
+++ b/IDL/constants.idl
@@ -21,6 +21,7 @@ const int32 const_int32 = 74;
 const uint32 const_uint32 = 64;
 const int64 const_int64 = 17;
 const uint64 const_uint64 = 19;
+// String consts are included in basic_inner_types.idl
 
 typedef short alias_short;
 const alias_short alias_const = 55;

--- a/IDL/helpers/basic_inner_types.idl
+++ b/IDL/helpers/basic_inner_types.idl
@@ -62,3 +62,7 @@ typedef sequence<short> Inner_alias_sequence_helper;
 typedef map<long, long> Inner_alias_map_helper;
 typedef InnerStructureHelper inner_structure_helper_alias;
 typedef InnerBitsetHelper inner_bitset_helper_alias;
+
+// String consts are checked here to avoid generating the related TypeObjectTest.
+const string const_string = "AAA";
+const wstring const_wstring = L"BBB";

--- a/IDL/inheritance.idl
+++ b/IDL/inheritance.idl
@@ -37,8 +37,9 @@ struct StructuresInheritanceStruct
     InnerStructureHelperChild var_InnerStructureHelperChild;
     InnerStructureHelperChildChild var_InnerStructureHelperChildChild;
     InnerStructureHelperEmptyChild var_InnerStructureHelperEmptyChild;
+    InnerStructureHelperEmptyChildChild var_InnerStructureHelperEmptyChildChild;
     InnerEmptyStructureHelperChild var_InnerEmptyStructureHelperChild;
-
+    StructAliasInheritanceStruct var_StructAliasInheritanceStruct;
 };
 
 bitset InnerBitsetHelperChild : InnerBitsetHelper

--- a/IDL/inheritance.idl
+++ b/IDL/inheritance.idl
@@ -19,7 +19,7 @@ struct InnerStructureHelperEmptyChild : InnerStructureHelper
 struct InnerStructureHelperEmptyChildChild : InnerStructureHelperEmptyChild
 {
     char var_char;
-}
+};
 
 struct InnerEmptyStructureHelperChild : InnerEmptyStructureHelper
 {

--- a/IDL/inheritance.idl
+++ b/IDL/inheritance.idl
@@ -16,6 +16,11 @@ struct InnerStructureHelperEmptyChild : InnerStructureHelper
 {
 };
 
+struct InnerStructureHelperEmptyChildChild : InnerStructureHelperEmptyChild
+{
+    char var_char;
+}
+
 struct InnerEmptyStructureHelperChild : InnerEmptyStructureHelper
 {
     long long var_child_longlong;

--- a/IDL/inheritance.idl
+++ b/IDL/inheritance.idl
@@ -48,7 +48,7 @@ bitset InnerBitsetHelperChild : InnerBitsetHelper
 
 bitset InnerBitsetHelperChildChild : InnerBitsetHelperChild
 {
-    bitfield<17> childchild_z;
+    bitfield<14> childchild_z;
 };
 
 bitset BitsetAliasInheritanceBitset : inner_bitset_helper_alias


### PR DESCRIPTION
This PR includes some test cases that were overlooked:

* Inherited structure from empty structure (correctly calculate MemberId when `@autoid` is SEQUENTIAL)
* Extend annotation test cases to support constant definitions and using aliases.
* Minor fixes (inherited bitset has more than 64 bits, ensure that every defined variable is used so the TypeObject tests works as expected)