### PR TITLE
[20213] Removed float128 from annotations.idl

### DIFF
--- a/IDL/annotations.idl
+++ b/IDL/annotations.idl
@@ -10,7 +10,6 @@
     unsigned long long var_ulonglong;
     float var_float;
     double var_double;
-    long double var_longdouble;
     boolean var_boolean;
     octet var_octet;
     char var_char8;
@@ -44,7 +43,6 @@
     var_ulonglong = 1,
     var_float = 1,
     var_double = 1,
-    var_longdouble = 1,
     var_boolean = true,
     var_octet = 0,
     var_char8 = 'a',


### PR DESCRIPTION
This type from this IDL is being removed due to undefined behavior when serializing/deserializing the value of a float128 variable 
 of an annotation.

This issue occurs when fastrtps is compiled in 'Debug' mode and fastcdr is compiled in 'Release' mode.

