### PR TITLE
New case for default union discriminator value [21235]

### DIFF
--- a/IDL/unions.idl
+++ b/IDL/unions.idl
@@ -497,3 +497,13 @@ struct UnionSeveralFieldsWithDefault
 {
     Union_Several_Fields_With_Default var_union_several_fields_with_default;
 };
+
+union DefaultAnnotation switch (@default(0) long)
+{
+    case 0:
+        octet a;
+    case 1:
+        short b;
+    default:
+        long c;
+};

--- a/IDL/unions.idl
+++ b/IDL/unions.idl
@@ -498,6 +498,7 @@ struct UnionSeveralFieldsWithDefault
     Union_Several_Fields_With_Default var_union_several_fields_with_default;
 };
 
+//! Test case for union discriminator's @default annotation.
 union DefaultAnnotation switch (@default(0) long)
 {
     case 0:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
-->
This PR adds a test case to check a new feature in Fast-DDS-Gen: it is allowed to use the `@default` annotation on union's discriminators.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Any new/modified type has been properly reflected on `test/feature/dynamic_types/dds_types_tests` tests in a Pull Request. <!-- It is mandatory to test new/modified tests with the Dynamic Type API -->
- *N/A* Any new/modified type has been properly updated on `test/dds/xtypes` tests using `update_header_and_create_cases.py` script in a Pull Request. <!-- It is mandatory to update the test source code using the script -->
- *N/A* For any new IDL file, Fast DDS `update_generated_code_from_idl.sh` script adding a new line in `file_needing_output_dir` list in a Pull Request. <!-- It is mandatory to generate always the code for new IDL files -->

## Reviewer Checklist
- _N/A_ The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
