### PR TITLE
[21824] Regression test for 21823

### DIFF
--- a/IDL/unions.idl
+++ b/IDL/unions.idl
@@ -536,7 +536,7 @@ struct UnionShortExtraMember
     long var_long;
 };
 
-//! Regression test for issue #21823. Note: union using a alias with scope.
+//! Regression test for issue #21823. Note: union using an alias with scope.
 struct UnionFixedStringAlias
 {
     Union_Fixed_String_In_Module_Alias var_union_fixed_string_in_module_alias;

--- a/IDL/unions.idl
+++ b/IDL/unions.idl
@@ -1,5 +1,10 @@
 #include "helpers/basic_inner_types.idl"
 
+module Fixed_String_Module
+{
+    typedef string<20> fixed_string_in_module;
+};
+
 union Union_Short switch (long)
 {
     case 0:
@@ -293,6 +298,12 @@ union Union_Several_Fields_With_Default switch (long)
         sequence<short, 30> f;
 };
 
+union Union_Fixed_String_In_Module_Alias switch (long)
+{
+    case 0:
+        Fixed_String_Module::fixed_string_in_module a;
+};
+
 struct UnionShort
 {
     Union_Short var_union_short;
@@ -523,4 +534,10 @@ struct UnionShortExtraMember
 {
     Union_Short var_union_short;
     long var_long;
+};
+
+//! Regression test for issue #21823. Note: union using a alias with scope.
+struct UnionFixedStringAlias
+{
+    Union_Fixed_String_In_Module_Alias var_union_fixed_string_in_module_alias;
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
-->
This PR adds a regression test for a bug when a union uses an alias with scope. `fastddsgen` generates code that doesn't compiile.

## Contributor Checklist
- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] Any new/modified type has been properly reflected on `test/feature/dynamic_types/dds_types_tests` tests in a Pull Request eprosima/fast-dds#5330. <!-- It is mandatory to test new/modified tests with the Dynamic Type API -->
- [x] Any new/modified type has been properly updated on `test/dds/xtypes` tests using `update_header_and_create_cases.py` script in a Pull Request eprosima/fast-dds#5330. <!-- It is mandatory to update the test source code using the script -->
- *N/A* For any new IDL file, Fast DDS `update_generated_code_from_idl.sh` script adding a new line in `file_needing_output_dir` list in a Pull Request. <!-- It is mandatory to generate always the code for new IDL files -->

## Reviewer Checklist
- _N/A_: The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
